### PR TITLE
moving the cleanup_thread_local to the after method for SlickBaseTest…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.slickqa</groupId>
     <artifactId>slickqa-testng</artifactId>
-    <version>1.0.0-6</version>
+    <version>1.0.0-7</version>
     <name>Slick TestNG Connector</name>
     <description>TestNG connector for the SlickQA results database.</description>
     <licenses>

--- a/src/main/java/com/slickqa/testng/SlickBaseTest.java
+++ b/src/main/java/com/slickqa/testng/SlickBaseTest.java
@@ -1,7 +1,5 @@
 package com.slickqa.testng;
 
-import com.slickqa.client.errors.SlickError;
-import org.testng.ITestContext;
 import org.testng.annotations.*;
 
 /**
@@ -13,6 +11,11 @@ import org.testng.annotations.*;
  */
 @Listeners({SlickSuite.class, SlickResult.class})
 public class SlickBaseTest {
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanupSlickBaseTest() {
+        SlickResult.cleanupThreadLocal();
+    }
 
     public SlickResultLogger slickLog() {
         SlickResultLogger slickResultLogger;

--- a/src/main/java/com/slickqa/testng/SlickResult.java
+++ b/src/main/java/com/slickqa/testng/SlickResult.java
@@ -86,7 +86,7 @@ public class SlickResult implements IResultListener2  {
         else {
             logger.debug("Not logging to slick");
         }
-        cleanupThreadLocal();
+        //cleanupThreadLocal();
     }
 
     @Override
@@ -120,7 +120,7 @@ public class SlickResult implements IResultListener2  {
         else {
             logger.debug("Not logging to slick");
         }
-        cleanupThreadLocal();
+        //cleanupThreadLocal();
     }
 
     @Override
@@ -145,7 +145,7 @@ public class SlickResult implements IResultListener2  {
         else {
             logger.debug("Not logging to slick");
         }
-        cleanupThreadLocal();
+        //cleanupThreadLocal();
     }
 
     public static SlickClient getThreadSlickClient() {
@@ -163,7 +163,7 @@ public class SlickResult implements IResultListener2  {
         return slickClient;
     }
 
-    private void cleanupThreadLocal() {
+    public static void cleanupThreadLocal() {
         if (threadCurrentResultId != null && threadCurrentResultId.get() != null) {
             threadCurrentResultId.remove();
         }


### PR DESCRIPTION
… so that tests that extend SlickBaseTest can actually attach files in the after method