### PR TITLE
Generic attributes when scheduling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.slickqa</groupId>
     <artifactId>slickqa-testng</artifactId>
-    <version>1.0.0-18</version>
+    <version>1.0.0-19</version>
     <name>Slick TestNG Connector</name>
     <description>TestNG connector for the SlickQA results database.</description>
     <licenses>
@@ -69,6 +69,12 @@
                         <goals>
                             <goal>sign</goal>
                         </goals>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/com/slickqa/testng/SlickTestNGController.java
+++ b/src/main/java/com/slickqa/testng/SlickTestNGController.java
@@ -361,10 +361,14 @@ public class SlickTestNGController {
                     result.setRunstatus("SCHEDULED");
                     result.setReason("scheduled");
                     String environment = System.getProperty("environment", "NOT_SET");
-                    String branch = System.getProperty("branch", "NOT_SET");
+
                     HashMap<String, String> attributes = new HashMap<String, String>();
+                    for(String property : System.getProperties().stringPropertyNames()) {
+                        if(property.startsWith("attr.")) {
+                            attributes.put(property.substring(5), System.getProperty(property));
+                        }
+                    }
                     attributes.put("environment", environment);
-                    attributes.put("branch", branch);
                     result.setAttributes(attributes);
                 }
                 result = getSlickClient().results().create(result);


### PR DESCRIPTION
This change allows generic attributes by looking through the system properties and using any system property starting with attr. and taking the rest of the key as the name, and setting the value.  Now we can have more than just branch, we can put whatever we want at runtime into attributes.