### PR TITLE
Updates to get distributed test execution working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.slickqa</groupId>
     <artifactId>slickqa-testng</artifactId>
-    <version>1.0.0-19</version>
+    <version>1.0.0-20</version>
     <name>Slick TestNG Connector</name>
     <description>TestNG connector for the SlickQA results database.</description>
     <licenses>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>com.slickqa</groupId>
             <artifactId>slickqa-java-client</artifactId>
-            <version>1.0.2-2</version>
+            <version>1.0.2-3</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.testng/testng -->
         <dependency>

--- a/src/main/java/com/slickqa/testng/ConfigurationNames.java
+++ b/src/main/java/com/slickqa/testng/ConfigurationNames.java
@@ -36,4 +36,11 @@ public class ConfigurationNames {
      * If both are missing then a combination of the date and time will be used.
      */
     static public final String TESTRUN_NAME = "slick.testrun";
+
+    /**
+     * The URL for the result to run.  If this is specified, and there is only one test being run, then a new result
+     * is not created.  Instead of creating a new result, the one specified in the URL is updated when the result
+     * finishes.
+     */
+    static public final String RESULT_URL = "slick.resulturl";
 }


### PR DESCRIPTION
You can now run a single result with the only parameter being the result id api url.  Schedule now exits after scheduling.