### PR TITLE
Fix to make triage notes work again after turning off logging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,9 @@ pipeline {
         stage('Build') {
             steps {
                 sh '''
+                    BRANCH_NO_SLASHES=$(echo $BRANCH_NAME |sed -e "s#/#-#g")
                     POM_BUILD_NUMBER=${BUILD_NUMBER}
-                    if [ "$BRANCH_NAME" != "master" ]; then POM_BUILD_NUMBER="${BRANCH_NAME}-${BUILD_NUMBER}"; fi
+                    if [ "$BRANCH_NAME" != "master" ]; then POM_BUILD_NUMBER="${BRANCH_NO_SLASHES}-${BUILD_NUMBER}"; fi
 
                     ORIGINAL_VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression='project.version')
                     NEW_VERSION=$(echo ${ORIGINAL_VERSION} | sed -e "s/SNAPSHOT/${POM_BUILD_NUMBER}/")

--- a/src/main/java/com/slickqa/testng/SlickResultLogger.java
+++ b/src/main/java/com/slickqa/testng/SlickResultLogger.java
@@ -74,7 +74,7 @@ public class SlickResultLogger implements SlickLogger {
 
     @Override
     public void addLogEntry(LogEntry entry) {
-        if(System.getProperty(ConfigurationNames.SLICK_ENABLE_LOGS, "false").equalsIgnoreCase("true")) {
+        if(System.getProperty(ConfigurationNames.SLICK_ENABLE_LOGS, "false").equalsIgnoreCase("true") || "slick.note".equals(entry.getLoggerName())) {
             if (SlickTestNGController.isUsingSlick() && !this.slickResultId.equals(SlickResultLogger.NOTDEFINED)) {
                 buffer.add(entry);
                 uploadLogsIfNecessary();


### PR DESCRIPTION
triage notes actually use the logging feature in slick, so when we turned off logging we broke triage notes.  This should fix that.